### PR TITLE
Add a cross-platform CLI, stable sort output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,5 +287,5 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 
-# Compiled CLI executable
-acmi-compiler-cli
+# compiled executable
+acmi-compiler

--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Compiled CLI executable
+acmi-compiler-cli

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+CXX ?= clang++
+CXXFLAGS ?= -std=c++17 -Wall -Wextra -g -O3
+
+acmi-compiler-cli: src/cli.cpp src/AcmiTape.cpp
+	$(CXX) $(CXXFLAGS) -pthread -o acmi-compiler-cli $^
+
+.PHONY: clean
+clean:
+	rm -f acmi-compiler-cli

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CXX ?= clang++
 CXXFLAGS ?= -std=c++17 -Wall -Wextra -g -O3
 
-acmi-compiler-cli: src/cli.cpp src/AcmiTape.cpp
-	$(CXX) $(CXXFLAGS) -pthread -o acmi-compiler-cli $^
+acmi-compiler: src/cli.cpp src/AcmiTape.cpp
+	$(CXX) $(CXXFLAGS) -pthread -o acmi-compiler $^
 
 .PHONY: clean
 clean:
-	rm -f acmi-compiler-cli
+	rm -f acmi-compiler

--- a/acmi-compiler-cli/acmi-compiler-cli.vcxproj
+++ b/acmi-compiler-cli/acmi-compiler-cli.vcxproj
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{961b1ce1-a393-44fc-b478-1711aebd3fb5}</ProjectGuid>
+    <RootNamespace>acmicompilercli</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\AcmiTape.cpp" />
+    <ClCompile Include="..\src\cli.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\Acmirec.h" />
+    <ClInclude Include="..\src\AcmiTape.h" />
+    <ClInclude Include="..\src\threading.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/acmi-compiler-cli/acmi-compiler-cli.vcxproj.filters
+++ b/acmi-compiler-cli/acmi-compiler-cli.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\AcmiTape.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cli.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\Acmirec.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\AcmiTape.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\threading.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/acmi-compiler.sln
+++ b/acmi-compiler.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31105.61
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "acmi-compiler", "acmi-compiler.vcxproj", "{0F32636C-0BB8-44CC-98CB-BB5952EADDCE}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "acmi-compiler-cli", "acmi-compiler-cli\acmi-compiler-cli.vcxproj", "{961B1CE1-A393-44FC-B478-1711AEBD3FB5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,19 @@ Global
 		{0F32636C-0BB8-44CC-98CB-BB5952EADDCE}.Release|x64.Build.0 = Release|x64
 		{0F32636C-0BB8-44CC-98CB-BB5952EADDCE}.Release|x86.ActiveCfg = Release|Win32
 		{0F32636C-0BB8-44CC-98CB-BB5952EADDCE}.Release|x86.Build.0 = Release|Win32
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Debug|x64.ActiveCfg = Debug|x64
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Debug|x64.Build.0 = Debug|x64
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Debug|x86.ActiveCfg = Debug|Win32
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Debug|x86.Build.0 = Debug|Win32
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Release|x64.ActiveCfg = Release|x64
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Release|x64.Build.0 = Release|x64
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Release|x86.ActiveCfg = Release|Win32
+		{961B1CE1-A393-44FC-B478-1711AEBD3FB5}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D19A98EB-97EC-496A-98EE-5E6E62DCFC83}
 	EndGlobalSection
 EndGlobal

--- a/src/AcmiTape.cpp
+++ b/src/AcmiTape.cpp
@@ -14,7 +14,7 @@
 #pragma warning(disable:4996)
 
 /* 
-** Look, I'm not gonna cast every single size_t of the code into long
+** Look, I'm not gonna cast every single size_t of the code into int32_t
 ** It serves the sames purpose as to disable the warning
 ** It doesn't change the fact that yes data might be lost 
 */
@@ -38,7 +38,7 @@
 
 using namespace std::chrono;
 
-long GetFileSize(std::string filename)
+int32_t GetFileSize(std::string filename)
 {
 	struct stat stat_buf;
 	int rc = stat(filename.c_str(), &stat_buf);
@@ -127,7 +127,7 @@ bool ACMITape::Import(const char* inFltFile, const char* outTapeFileName)
 	float endTime = 0.0;
 	bool corrupted = false;
 
-	long filesize = GetFileSize(inFltFile);
+	int32_t filesize = GetFileSize(inFltFile);
 
 	// Load flight file for positional data.
 	flightFile = fopen(inFltFile, "rb");
@@ -317,7 +317,7 @@ bool ACMITape::Import(const char* inFltFile, const char* outTapeFileName)
 
 			// fill in data
 			ehdr.eventType = hdr.type;
-			// ehdr.index = static_cast<long>(importEventVec.size());
+			// ehdr.index = static_cast<int32_t>(importEventVec.size());
 			ehdr.index = importEventVec.size();
 			ehdr.time = hdr.time;
 			ehdr.timeEnd = hdr.time + msfx.timeToLive;
@@ -434,7 +434,7 @@ bool ACMITape::Import(const char* inFltFile, const char* outTapeFileName)
 		case ACMICallsignList:
 
 			// Read the data
-			if (!fread(&import_count, sizeof(long), 1, flightFile))
+			if (!fread(&import_count, sizeof(int32_t), 1, flightFile))
 			{
 				corrupted = true;
 				MonoPrint("%s[WARNING] Error reading ACMICallsignList%s\n", COLOR_YELLOW, COLOR_RESET);
@@ -661,9 +661,9 @@ void ACMITape::ThreadEntityPositions(ACMITapeHeader* tapeHdr)
 	// entity and chains them together
 	par_for(0, importEntityVecSize, [&](size_t i)
 		{
-			long currOffset;
+			int32_t currOffset;
 			bool foundFirst = false;
-			long prevOffset = 0;
+			int32_t prevOffset = 0;
 			importEntityVec[i].firstPositionDataOffset = 0;
 			int prevPosVec = -1;
 
@@ -724,9 +724,9 @@ void ACMITape::ThreadEntityPositions(ACMITapeHeader* tapeHdr)
 	// Feature and chains them together
 	par_for(0, importFeatVecSize, [&](size_t i)
 		{
-			long currOffset;
+			int32_t currOffset;
 			bool foundFirst = false;
-			long prevOffset = 0;
+			int32_t prevOffset = 0;
 			importFeatVec[i].firstPositionDataOffset = 0;
 			int prevPosVec = -1;
 
@@ -842,9 +842,9 @@ void ACMITape::ThreadEntityEvents(ACMITapeHeader* tapeHdr)
 	*/
 	par_for(0, importEntityVecSize, [&](size_t i)
 		{
-			long currOffset;
+			int32_t currOffset;
 			bool foundFirst = false;
-			long prevOffset = 0;
+			int32_t prevOffset = 0;
 			importEntityVec[i].firstEventDataOffset = 0;
 
 			int prevPosVec = -1;
@@ -1088,7 +1088,7 @@ void ACMITape::ImportTextEventList(FILE* fd, ACMITapeHeader* tapeHdr)
 	// write callsign list
 	if (Import_Callsigns)
 	{
-		ret = fwrite(&import_count, sizeof(long), 1, fd);
+		ret = fwrite(&import_count, sizeof(int32_t), 1, fd);
 		if (!ret)
 			goto error_exit;
 

--- a/src/AcmiTape.cpp
+++ b/src/AcmiTape.cpp
@@ -57,17 +57,17 @@ bool compare_uniq_id(ACMIRawPositionData i, ACMIRawPositionData j)
 
 /*
 ** https://stackoverflow.com/questions/21675846/c11-using-stdequal-range-with-custom-comparison-function
-** Because equal_range checks both "int < foreign type" and "foreign type < int"
+** Because equal_range checks both "int32_t < foreign type" and "foreign type < int32_t"
 ** We need a checking function that can accept both types at both places
 */
 struct comp
 {
-	bool operator() (const ACMIRawPositionData& a, const int& b) const
+	bool operator() (const ACMIRawPositionData& a, const int32_t& b) const
 	{
 		return a.uniqueID < b;
 	}
 
-	bool operator() (const int& a, const ACMIRawPositionData& b) const
+	bool operator() (const int32_t& a, const ACMIRawPositionData& b) const
 	{
 		return a < b.uniqueID;
 	}
@@ -607,7 +607,7 @@ void ACMITape::ParseEntities(void)
 	** I have no Idea if it's really usefull as Tacview doesn't seem to be using those values.
 	** But they were doing that in the original code so *shrug*
 	*/
-	int objCount;
+	int32_t objCount;
 
 	size_t i = 0;
 	size_t j = 0;
@@ -665,7 +665,7 @@ void ACMITape::ThreadEntityPositions(ACMITapeHeader* tapeHdr)
 			bool foundFirst = false;
 			int32_t prevOffset = 0;
 			importEntityVec[i].firstPositionDataOffset = 0;
-			int prevPosVec = -1;
+			int32_t prevPosVec = -1;
 
 			std::pair<std::vector<ACMIRawPositionData>::iterator, std::vector<ACMIRawPositionData>::iterator> bounds;
 
@@ -728,7 +728,7 @@ void ACMITape::ThreadEntityPositions(ACMITapeHeader* tapeHdr)
 			bool foundFirst = false;
 			int32_t prevOffset = 0;
 			importFeatVec[i].firstPositionDataOffset = 0;
-			int prevPosVec = -1;
+			int32_t prevPosVec = -1;
 
 			std::pair<std::vector<ACMIRawPositionData>::iterator, std::vector<ACMIRawPositionData>::iterator> bounds;
 
@@ -847,7 +847,7 @@ void ACMITape::ThreadEntityEvents(ACMITapeHeader* tapeHdr)
 			int32_t prevOffset = 0;
 			importEntityVec[i].firstEventDataOffset = 0;
 
-			int prevPosVec = -1;
+			int32_t prevPosVec = -1;
 
 			std::pair<std::vector<ACMIRawPositionData>::iterator, std::vector<ACMIRawPositionData>::iterator> bounds;
 

--- a/src/AcmiTape.h
+++ b/src/AcmiTape.h
@@ -34,23 +34,23 @@ typedef unsigned char BYTE;
 #pragma pack (push, pack1, 1)
 typedef struct ACMITapeHeader
 {
-	long		fileID = 0;
-	long		fileSize = 0;
-	long		numEntities = 0;
-	long		numFeat = 0;
-	long 		entityBlockOffset = 0;			// 5th
-	long 		featBlockOffset = 0;
-	long		numEntityPositions = 0;
-	long		timelineBlockOffset = 0;
-	long		firstEntEventOffset = 0;
-	long		firstGeneralEventOffset = 0;	// 10th => 40 Bytes
-	long		firstEventTrailerOffset = 0;
-	long		firstTextEventOffset = 0;
-	long		firstFeatEventOffset = 0;
-	long		numEvents = 0;
-	long		numEntEvents = 0;				// 15th => 60 Byte
-	long		numTextEvents = 0;
-	long		numFeatEvents = 0;
+	int32_t		fileID = 0;
+	int32_t		fileSize = 0;
+	int32_t		numEntities = 0;
+	int32_t		numFeat = 0;
+	int32_t 		entityBlockOffset = 0;			// 5th
+	int32_t 		featBlockOffset = 0;
+	int32_t		numEntityPositions = 0;
+	int32_t		timelineBlockOffset = 0;
+	int32_t		firstEntEventOffset = 0;
+	int32_t		firstGeneralEventOffset = 0;	// 10th => 40 Bytes
+	int32_t		firstEventTrailerOffset = 0;
+	int32_t		firstTextEventOffset = 0;
+	int32_t		firstFeatEventOffset = 0;
+	int32_t		numEvents = 0;
+	int32_t		numEntEvents = 0;				// 15th => 60 Byte
+	int32_t		numTextEvents = 0;
+	int32_t		numFeatEvents = 0;
 	float		startTime = 0;
 	float		totPlayTime = 0;
 	float 		todOffset = 0;
@@ -64,10 +64,10 @@ typedef struct ACMITapeHeader
 #pragma pack (push, pack1, 1)
 typedef struct ACMIEntityData
 {
-	long		uniqueID = 0;
-	long		type = 0;
-	long		count = 0;
-	long		flags = 0;
+	int32_t		uniqueID = 0;
+	int32_t		type = 0;
+	int32_t		count = 0;
+	int32_t		flags = 0;
 	
 		#define		ENTITY_FLAG_MISSILE			0x00000001
 		#define		ENTITY_FLAG_FEATURE			0x00000002
@@ -77,14 +77,14 @@ typedef struct ACMIEntityData
 
 	// for features we may need an index to the lead component and
 	// the slot # that was in the camp component list (for bridges, bases...)
-	long		leadIndex = 0;
+	int32_t		leadIndex = 0;
 	int			slot = 0;
 	int			specialFlags = 0;
 
 
 	// Offset from the start of the file to the start of my positional data.
-	long 		firstPositionDataOffset = 0;
-	long 		firstEventDataOffset = 0;
+	int32_t 		firstPositionDataOffset = 0;
+	int32_t 		firstEventDataOffset = 0;
 
 } ACMIEntityData;
 #pragma pack (pop, pack1)
@@ -120,7 +120,7 @@ typedef struct ACMIEntityPositionData
 			float		pitch = 0.0;
 			float		roll = 0.0;
 			float		yaw = 0.0;
-			long	    radarTarget = 0;
+			int32_t	    radarTarget = 0;
 		} posData;
 		// switch change
 		struct
@@ -141,8 +141,8 @@ typedef struct ACMIEntityPositionData
 	// Although position data is a fixed size, we still want
 	// this so that we can organize the data to be friendly for
 	// paging.
-	long		nextPositionUpdateOffset = 0;
-	long		prevPositionUpdateOffset = 0;
+	int32_t		nextPositionUpdateOffset = 0;
+	int32_t		prevPositionUpdateOffset = 0;
 } ACMIEntityPositionData;
 #pragma pack (pop, pack1)
 
@@ -154,12 +154,12 @@ typedef struct ACMIEntityPositionData
 typedef struct ACMIRawPositionData
 {
 	int			type = 0;			// type of object
-	long		uniqueID = 0;		// A unique ID for the object. Many to One correlation to Falcon Entities
+	int32_t		uniqueID = 0;		// A unique ID for the object. Many to One correlation to Falcon Entities
 	int			flags = 0;			// side
 
 	// for features we may need an index to the lead component and
 	// the slot # that was in the camp component list (for bridges, bases...)
-	long		leadIndex = 0;
+	int32_t		leadIndex = 0;
 	int			slot = 0;
 	int			specialFlags = 0;
 	ACMIEntityPositionData entityPosData = {};
@@ -174,16 +174,16 @@ typedef struct ACMIEventHeader
 {
 	// type of event this is
 	BYTE		eventType = 0;
-	long 		index = -42;
+	int32_t 		index = -42;
 
 	// Time stamp for this event.
 	float		time = 0;
 	float		timeEnd = 0;
 
 	// data specific to type of event
-	long		type = 0;
-	long		user = 0;
-	long		flags = 0;
+	int32_t		type = 0;
+	int32_t		user = 0;
+	int32_t		flags = 0;
 	float		scale = 0;
 	float		x = 0;
 	float		y = 0;
@@ -206,7 +206,7 @@ typedef struct ACMIEventHeader
 typedef struct ACMIEventTrailer
 {
 	float		timeEnd = 0;
-	long 		index = 0;		// into EventHeader
+	int32_t 		index = 0;		// into EventHeader
 } ACMIEventTrailer;
 #pragma pack (pop, pack1)
 
@@ -221,18 +221,18 @@ typedef struct ACMIFeatEvent
 	float		time = 0.0;
 
 	// index of feature on tape
-	long 		index = 0;
+	int32_t 		index = 0;
 
 	// data specific to type of event
-	long		newStatus = 0;
-	long		prevStatus = 0;
+	int32_t		newStatus = 0;
+	int32_t		prevStatus = 0;
 
 } ACMIFeatEvent;
 #pragma pack (pop, pack1)
 
 typedef struct ACMIFeatEventImportData
 {
-	long		uniqueID = 0;
+	int32_t		uniqueID = 0;
 	ACMIFeatEvent data;
 } ACMIFeatEventImportData;
 
@@ -252,7 +252,7 @@ typedef struct ACMIFeatEventImportData
 //
 // |                    |                                       |
 // | number of entities |              entities                 |    
-// |  sizeof(long)      | num entities * sizeof(ACMIEntityData) |
+// |  sizeof(int32_t)      | num entities * sizeof(ACMIEntityData) |
 //
 // entity:
 //
@@ -294,8 +294,8 @@ typedef struct ACMIFeatEventImportData
 
 typedef struct ACMIEntityReadHead
 {
-	long			positionDataOffset = 0;
-	long			eventDataOffset = 0;
+	int32_t			positionDataOffset = 0;
+	int32_t			eventDataOffset = 0;
 } ACMIEntityReadHead;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -325,7 +325,7 @@ private:
 	bool WriteTapeFile(const char *fname, ACMITapeHeader *tapeHdr);
 
 
-	long tempTarget = 0; // for missile lock.
+	int32_t tempTarget = 0; // for missile lock.
 	
 	/*Converted list to vector*/
 	std::vector<ACMIEntityData> importEntityVec;				// List of entities
@@ -337,7 +337,7 @@ private:
 
 
 	std::unique_ptr<ACMI_CallRec[]> Import_Callsigns;
-	long import_count = 0;
+	int32_t import_count = 0;
 
 
 };

--- a/src/AcmiTape.h
+++ b/src/AcmiTape.h
@@ -78,8 +78,8 @@ typedef struct ACMIEntityData
 	// for features we may need an index to the lead component and
 	// the slot # that was in the camp component list (for bridges, bases...)
 	int32_t		leadIndex = 0;
-	int			slot = 0;
-	int			specialFlags = 0;
+	int32_t			slot = 0;
+	int32_t			specialFlags = 0;
 
 
 	// Offset from the start of the file to the start of my positional data.
@@ -125,14 +125,14 @@ typedef struct ACMIEntityPositionData
 		// switch change
 		struct
 		{
-			int			switchNum = 0;
-			int			switchVal = 0;
-			int			prevSwitchVal = 0;
+			int32_t			switchNum = 0;
+			int32_t			switchVal = 0;
+			int32_t			prevSwitchVal = 0;
 		} switchData;
 		// DOF change
 		struct
 		{
-			int			DOFNum = 0;
+			int32_t			DOFNum = 0;
 			float		DOFVal = 0.0;
 			float		prevDOFVal = 0.0;
 		} dofData;
@@ -153,15 +153,15 @@ typedef struct ACMIEntityPositionData
 
 typedef struct ACMIRawPositionData
 {
-	int			type = 0;			// type of object
+	int32_t			type = 0;			// type of object
 	int32_t		uniqueID = 0;		// A unique ID for the object. Many to One correlation to Falcon Entities
-	int			flags = 0;			// side
+	int32_t			flags = 0;			// side
 
 	// for features we may need an index to the lead component and
 	// the slot # that was in the camp component list (for bridges, bases...)
 	int32_t		leadIndex = 0;
-	int			slot = 0;
-	int			specialFlags = 0;
+	int32_t			slot = 0;
+	int32_t			specialFlags = 0;
 	ACMIEntityPositionData entityPosData = {};
 } ACMIRawPositionData;
 

--- a/src/Acmirec.h
+++ b/src/Acmirec.h
@@ -11,7 +11,6 @@
 #ifndef _ACMIREC_H_
 #define _ACMIREC_H_
 
-#include "tchar.h"
 typedef unsigned char BYTE;
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -95,19 +94,6 @@ typedef struct ACMIFeaturePositionData
 	float 	roll = 0;
 } ACMIFeaturePositionData;
 #pragma pack (pop, pack1)
-
-/*
-** ACMI Text event (strings parsed from event file)
-** Which we don't have, so this is never used
-*/
-//#pragma pack (push, pack1, 1)
-//typedef struct
-//{
-//	long	   intTime;
-//	_TCHAR timeStr[20];
-//	_TCHAR msgStr[100];
-//} ACMITextEvent;
-//#pragma pack (pop, pack1)
 
 //
 // ACMISwitchData

--- a/src/Acmirec.h
+++ b/src/Acmirec.h
@@ -11,7 +11,8 @@
 #ifndef _ACMIREC_H_
 #define _ACMIREC_H_
 
-typedef unsigned char BYTE;
+#include <cstdint>
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,7 +52,7 @@ enum
 #pragma pack (push, pack1, 1)
 typedef struct ACMIRecHeader
 {
-	BYTE		type = 0;		// one of the ennumerated types
+	uint8_t		type = 0;		// one of the ennumerated types
 	float		time = 0.0;		// time stamp
 } ACMIRecHeader;
 #pragma pack (pop, pack1)
@@ -64,7 +65,7 @@ typedef struct ACMIRecHeader
 typedef struct ACMIGenPositionData
 {
 	int		type = 0;			// base type for creating simbase object
-	long	uniqueID = 0;		// identifier of instance
+	int32_t	uniqueID = 0;		// identifier of instance
 	float	x = 0.0;
 	float	y = 0;
 	float	z = 0;
@@ -82,8 +83,8 @@ typedef struct ACMIGenPositionData
 typedef struct ACMIFeaturePositionData
 {
 	int		type = 0;			// base type for creating simbase object
-	long	uniqueID = 0;		// identifier of instance
-	long	leadUniqueID = 0;	// id of lead component (for bridges. bases etc)
+	int32_t	uniqueID = 0;		// identifier of instance
+	int32_t	leadUniqueID = 0;	// id of lead component (for bridges. bases etc)
 	int		slot = 0;			// slot number in component list
 	int		specialFlags = 0;   // campaign feature flag
 	float	x = 0;
@@ -103,7 +104,7 @@ typedef struct ACMIFeaturePositionData
 typedef struct ACMISwitchData
 {
 	int		type = 0;			// base type for creating simbase object
-	long	uniqueID = 0;		// identifier of instance
+	int32_t	uniqueID = 0;		// identifier of instance
 	int		switchNum = 0;
 	int		switchVal = 0;
 	int		prevSwitchVal = 0;
@@ -117,7 +118,7 @@ typedef struct ACMISwitchData
 #pragma pack (push, pack1, 1)
 typedef struct ACMIFeatureStatusData
 {
-	long	uniqueID = 0;		// identifier of instance
+	int32_t	uniqueID = 0;		// identifier of instance
 	int		newStatus = 0;
 	int		prevStatus = 0;
 } ACMIFeatureStatusData;
@@ -131,7 +132,7 @@ typedef struct ACMIFeatureStatusData
 typedef struct ACMIDOFData
 {
 	int		type = 0;			// base type for creating simbase object
-	long	uniqueID = 0;		// identifier of instance
+	int32_t	uniqueID = 0;		// identifier of instance
 	int		DOFNum = 0;
 	float	DOFVal = 0.0;
 	float	prevDOFVal = 0.0;
@@ -240,7 +241,7 @@ typedef struct ACMIAircraftPositionRecord
 {
 	ACMIRecHeader				hdr;
 	ACMIGenPositionData			data;
-	long						RadarTarget;
+	int32_t						RadarTarget;
 	
 } ACMIAircraftPositionRecord;
 
@@ -287,7 +288,7 @@ typedef struct ACMIDOFRecord
 struct ACMI_CallRec
 {
 	char label[16];
-	long teamColor;
+	int32_t teamColor;
 };
 #pragma pack()
 

--- a/src/Acmirec.h
+++ b/src/Acmirec.h
@@ -64,7 +64,7 @@ typedef struct ACMIRecHeader
 #pragma pack (push, pack1, 1)
 typedef struct ACMIGenPositionData
 {
-	int		type = 0;			// base type for creating simbase object
+	int32_t		type = 0;			// base type for creating simbase object
 	int32_t	uniqueID = 0;		// identifier of instance
 	float	x = 0.0;
 	float	y = 0;
@@ -82,11 +82,11 @@ typedef struct ACMIGenPositionData
 #pragma pack (push, pack1, 1)
 typedef struct ACMIFeaturePositionData
 {
-	int		type = 0;			// base type for creating simbase object
+	int32_t		type = 0;			// base type for creating simbase object
 	int32_t	uniqueID = 0;		// identifier of instance
 	int32_t	leadUniqueID = 0;	// id of lead component (for bridges. bases etc)
-	int		slot = 0;			// slot number in component list
-	int		specialFlags = 0;   // campaign feature flag
+	int32_t		slot = 0;			// slot number in component list
+	int32_t		specialFlags = 0;   // campaign feature flag
 	float	x = 0;
 	float	y = 0;
 	float	z = 0;
@@ -103,11 +103,11 @@ typedef struct ACMIFeaturePositionData
 #pragma pack (push, pack1, 1)
 typedef struct ACMISwitchData
 {
-	int		type = 0;			// base type for creating simbase object
+	int32_t		type = 0;			// base type for creating simbase object
 	int32_t	uniqueID = 0;		// identifier of instance
-	int		switchNum = 0;
-	int		switchVal = 0;
-	int		prevSwitchVal = 0;
+	int32_t		switchNum = 0;
+	int32_t		switchVal = 0;
+	int32_t		prevSwitchVal = 0;
 } ACMISwitchData;
 #pragma pack (pop, pack1)
 
@@ -119,8 +119,8 @@ typedef struct ACMISwitchData
 typedef struct ACMIFeatureStatusData
 {
 	int32_t	uniqueID = 0;		// identifier of instance
-	int		newStatus = 0;
-	int		prevStatus = 0;
+	int32_t		newStatus = 0;
+	int32_t		prevStatus = 0;
 } ACMIFeatureStatusData;
 #pragma pack (pop, pack1)
 
@@ -131,9 +131,9 @@ typedef struct ACMIFeatureStatusData
 #pragma pack (push, pack1, 1)
 typedef struct ACMIDOFData
 {
-	int		type = 0;			// base type for creating simbase object
+	int32_t		type = 0;			// base type for creating simbase object
 	int32_t	uniqueID = 0;		// identifier of instance
-	int		DOFNum = 0;
+	int32_t		DOFNum = 0;
 	float	DOFVal = 0.0;
 	float	prevDOFVal = 0.0;
 } ACMIDOFData;
@@ -163,7 +163,7 @@ typedef struct ACMITracerStartData
 #pragma pack (push, pack1, 1)
 typedef struct ACMIStationarySfxData
 {
-	int		type = 0;		// sfx type
+	int32_t		type = 0;		// sfx type
 	float	x = 0.0;			// position
 	float	y = 0.0;
 	float	z = 0.0;
@@ -179,9 +179,9 @@ typedef struct ACMIStationarySfxData
 #pragma pack (push, pack1, 1)
 typedef struct ACMIMovingSfxData
 {
-	int		type = 0;		// sfx type
-	int		user = 0;		// misc data
-	int		flags = 0;
+	int32_t		type = 0;		// sfx type
+	int32_t		user = 0;		// misc data
+	int32_t		flags = 0;
 	float	x = 0.0;		// position
 	float	y = 0.0;
 	float	z = 0.0;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,0 +1,32 @@
+#include "AcmiTape.h"
+
+#include <cstdio>
+#include <chrono>
+
+using namespace std::chrono;
+
+int main(int argc, char* argv[])
+{
+	if (argc != 3)
+	{
+		fprintf(stderr, "Usage:\n./acmi-compiler.exe source-File.flt destination-File.vhs\n");
+		return -1;
+	}
+
+	ACMITape newtape;
+	const auto t = steady_clock::now();
+
+	printf("----- Starting conversion -----\n\n");
+	if (newtape.Import(argv[1], argv[2]))
+	{
+		const duration<float> elapsed = steady_clock::now() - t;
+		printf("\n----- File converted with success in %f seconds. -----\n", elapsed.count());
+		return 0;
+	}
+	else
+	{
+		printf("\n[ERROR] - ERROR DURING THE CONVERSION SEE ABOVE ERROR\n");
+		return -1;
+	}
+}
+


### PR DESCRIPTION
- Use a stable sort for event trailers so that the output file doesn't change as STL implementations of `qsort()` do.
- Fix a lot of portability issues (`long` is 32 bits in MSVC and 64 bits in GCC/Clang, for example)
- Add a simple cross-platform CLI (see `cli.cpp`) and a VS 2019 project for it.